### PR TITLE
create list with attributes that need an update on the fly

### DIFF
--- a/convert-config.cfg
+++ b/convert-config.cfg
@@ -1,39 +1,22 @@
-# copy settings from CMIP6Plus_CV.json
+# copy the settings from CMIP6Plus_CV.json
+#
+# Syntax: attr_name=attr_value
 
-authors="SMHI"
-comment="This experiment was done as part of OptimESM (https://optimesm-he.eu/) by ${authors}"
-
+# The source_id is required
+# 
 source_id="EC-Earth3-ESM-1"
 
-### define experiment ###
 
-case $experiment_id in
-    esm-piControl )
-        experiment="pre-industrial control simulation with preindustrial CO2 emissions defined (CO2 emission-driven)"
-        description="DECK: control (emission-driven)"
-        parent_source_id=$source_id
-        parent_experiment_id="esm-piControl-spinup"
-        ;;
-    esm-hist )
-        experiment="all-forcing simulation of the recent past with atmospheric CO2 concentration calculated (CO2 emission-driven)"
-        description="CMIP6 historical (CO2 emission-driven)"
-        parent_source_id=$source_id
-        parent_experiment_id="esm-piControl"
-        ;;
-    * )
-        echo "*** ERROR: settings for experiment $experiment_id not defined in $config ***"
-        ;;
-esac
-
-
-### lines below need to be adjusted once ###
-
-institution_id="EC-Earth-Consortium"
+# List of attributes that have changed in CMIP6Plus
+#
 institution="EC-Earth-Consortium - EC-Earth-Consortium [consortium]"
 
 source="EC-Earth3-ESM-1 (2024): \naerosol: none\natmos: IFS cy36r4 (TL255, linearly reduced Gaussian grid equivalent to 512 x 256 longitude/latitude; 91 levels; top level 0.01 hPa) and co2box v1.0 (CO2 box model; global grid)\natmosChem: none\nland: HTESSEL (land surface scheme built in IFS) and LPJ-GUESS v4.1.2\nlandIce: PISM v1.2 (5 km x 5 km for Greenland, 31 levels)\nocean: NEMO3.6 (ORCA1 tripolar primarily 1 degree with meridional refinement down to 1/3 degree in the tropics; 362 x 292 longitude/latitude; 75 levels; top grid cell 0-1 m) and MWE v1.0 (Melt Water Emulator; same grid as ocean for the Antarctic surroundings) \nocnBgchem: PISCES v2 (same grid as ocean)\nseaIce: LIM3 (same grid as ocean))"
 
-license="CMIP6Plus model data produced by ${institution_id} is licensed under a Creative Commons 4.0 (CC BY 4.0) License (https://creativecommons.org/licenses). Consult https://pcmdi.llnl.gov/CMIP6Plus/TermsOfUse for terms of use governing CMIP6Plus output, including citation requirements and proper acknowledgment. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law."
+license="CMIP6Plus model data produced by EC-Earth-Consortium is licensed under a Creative Commons 4.0 (CC BY 4.0) License (https://creativecommons.org/licenses). Consult https://pcmdi.llnl.gov/CMIP6Plus/TermsOfUse for terms of use governing CMIP6Plus output, including citation requirements and proper acknowledgment. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law."
 
-history_addition="The cmorMDfixer CMIP6 => CMIP6Plus convertscript has been applied.;\n"
+
+# Add new attributes (not in CV)
+#
+comment="This experiment was done as part of OptimESM (https://optimesm-he.eu/) by SMHI"
 


### PR DESCRIPTION
This update enables users to control the attributes that need to be updated in the config file.

So far only esm-piControl and esm-historical are supported. 