### PR TITLE
Fixes and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,38 @@ In order to see whether there is more than one version in your data:
 If so (this happens when during running the script the date changed because you crossed midnight), you need to set one version (you can choose what you want, but it should be a different and later date than the one which was previously published). One can set the date for instance to September 20 2024 by:
 ```shell
 ./versions.sh -v v20240920 -m CMIP6/
+```
+
+## 4. Convert an existing CMIP6 directory tree to CMIP6Plus
+
+The ``convert-cmor-table-var-in-drs-and-metadata.sh`` script changes variable and table names to CMIP6Plus standards, updates attributes and adjusts the DRS.
+
+```shell
+Usage: ./convert-cmor-table-var-in-drs-and-metadata.sh [-h] [-d] [-v] [-o] [-l log_file] [-c config_file] DIR
+    -h : show help message
+    -d : don't duplicate data (default: copy data)
+    -v : switch on verbose (default: off)
+    -o : overwrite existing files (default: false)
+    -l : log_file (default: ./convert-cmor-table-var-in-drs-and-metadata.log)
+    -c : configuration file (default: convert-ecearth.cfg)
+    DIR : path to CMIP6 directory
+```
+
+The configuration file holds a collection of all (global) attributes that should be updated when converting CMIP6 to CMIP6Plus. The example config file (convert-ecearth.cfg) includes the changes for EC-Earth3-ESM-1. Copy this file and edit settings for your model, then launch the conversion with ``-c your_config_file.cfg``
+
+Some attributes are updated automatically and don't need to be included in the config file:
+- mip_era
+- parent_mip_era
+- table_id
+- variable_id
+- experiment
+- description (new attribute for CMIP6Plus)
+- further_info_url (will be deleted)
+- history
+
+Without the ``-d`` option the script copies data from an existing CMIP6 to a CMIP6Plus directory. With ``-d`` the files are moved instad, no backup. Use with caution!
+
+Datasets in the CMIP6 directory that cannot be mapped to CMIP6Plus datasets will be left untouched.
+
+
+

--- a/convert-ecearth.cfg
+++ b/convert-ecearth.cfg
@@ -2,13 +2,12 @@
 #
 # Syntax: attr_name=attr_value
 
-# The source_id is required
-# 
-source_id="EC-Earth3-ESM-1"
-
-
 # List of attributes that have changed in CMIP6Plus
-#
+
+title="EC-Earth3-ESM-1 output prepared for"
+# yes, the "title" is truncated for CMIP6Plus, something missing at the end
+# see https://github.com/PCMDI/cmor/issues/776
+
 institution="EC-Earth-Consortium - EC-Earth-Consortium [consortium]"
 
 source="EC-Earth3-ESM-1 (2024): \naerosol: none\natmos: IFS cy36r4 (TL255, linearly reduced Gaussian grid equivalent to 512 x 256 longitude/latitude; 91 levels; top level 0.01 hPa) and co2box v1.0 (CO2 box model; global grid)\natmosChem: none\nland: HTESSEL (land surface scheme built in IFS) and LPJ-GUESS v4.1.2\nlandIce: PISM v1.2 (5 km x 5 km for Greenland, 31 levels)\nocean: NEMO3.6 (ORCA1 tripolar primarily 1 degree with meridional refinement down to 1/3 degree in the tropics; 362 x 292 longitude/latitude; 75 levels; top grid cell 0-1 m) and MWE v1.0 (Melt Water Emulator; same grid as ocean for the Antarctic surroundings) \nocnBgchem: PISCES v2 (same grid as ocean)\nseaIce: LIM3 (same grid as ocean))"
@@ -16,7 +15,7 @@ source="EC-Earth3-ESM-1 (2024): \naerosol: none\natmos: IFS cy36r4 (TL255, linea
 license="CMIP6Plus model data produced by EC-Earth-Consortium is licensed under a Creative Commons 4.0 (CC BY 4.0) License (https://creativecommons.org/licenses). Consult https://pcmdi.llnl.gov/CMIP6Plus/TermsOfUse for terms of use governing CMIP6Plus output, including citation requirements and proper acknowledgment. The data producers and data providers make no warranty, either express or implied, including, but not limited to, warranties of merchantability and fitness for a particular purpose. All liabilities arising from the supply of the information (including any liability arising in negligence) are excluded to the fullest extent permitted by law."
 
 
-# Add new attributes (not in CV)
-#
+# Optionally add new attributes (not in CV)
+
 comment="This experiment was done as part of OptimESM (https://optimesm-he.eu/) by SMHI"
 


### PR DESCRIPTION
A number of useful updates:
- update documentation in README.md
- rename convert-config.cfg to convert-ecearth.cfg
- add top level sanity check, abort quickly if there is no CMIP6 directory
- add overwrite flag. Check and don't process already existing CMIP6Plus files unless ``-o`` is set. Processing includes both cp/mv and updating the metadata.